### PR TITLE
pg unfollow confirm

### DIFF
--- a/lib/heroku_cli/pg.rb
+++ b/lib/heroku_cli/pg.rb
@@ -29,7 +29,7 @@ module HerokuCLI
     def un_follow(database, wait: false)
       raise "Not a following database #{database.name}" unless database.follower?
 
-      heroku "pg:unfollow #{database.url_name}", "-c #{application.name}"
+      heroku "pg:unfollow #{database.url_name} -c #{application.name}"
       wait_for_follow_fork_transformation(database) if wait
     end
 

--- a/lib/heroku_cli/version.rb
+++ b/lib/heroku_cli/version.rb
@@ -1,3 +1,3 @@
 module HerokuCLI
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/heroku_cli/pg_spec.rb
+++ b/spec/heroku_cli/pg_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe HerokuCLI::PG do
 
     it 'will unfollow' do
       database = subject.followers.first
-      expect(subject).to receive(:heroku).with("pg:unfollow HEROKU_POSTGRESQL_ORANGE_URL", "-c test")
+      expect(subject).to receive(:heroku).with("pg:unfollow HEROKU_POSTGRESQL_ORANGE_URL -c test")
       subject.un_follow(database)
     end
   end


### PR DESCRIPTION
pg:unfollow confirm should not be passed as args to unfollow command

bumped to version 0.2.2